### PR TITLE
21: Set background image to covering

### DIFF
--- a/components/Project/Project.module.css
+++ b/components/Project/Project.module.css
@@ -7,8 +7,12 @@
   @apply -top-2;
 }
 
-.image {
+.imageContainer {
   @apply absolute top-0 left-0 w-full h-full opacity-20 -z-[1] rounded-md;
+}
+
+.image {
+  @apply object-cover;
 }
 
 .description {

--- a/components/Project/Project.tsx
+++ b/components/Project/Project.tsx
@@ -10,7 +10,7 @@ import Badge from '../Badge/Badge';
 import animationStyles from '../../styles/animations.module.css';
 import { blurImageUrl } from '../../constants/image';
 import styles from './Project.module.css';
-import { Project as IProject } from "../../types/project";
+import { Project as IProject } from '../../types/project';
 
 export type ProjectProps = IProject;
 
@@ -43,9 +43,10 @@ const Project: React.FC<ProjectProps> = ({
       data-testid="project"
     >
       {imageUrl && (
-        <div className={styles.image}>
+        <div className={styles.imageContainer}>
           <Image
             src={imageUrl}
+            className={styles.image}
             alt="background-image"
             layout="fill"
             placeholder="blur"


### PR DESCRIPTION
- Use object-fit: cover to prevent breaking the aspect ratio for project images