### PR TITLE
65 new blog entry pages without redeploying

### DIFF
--- a/pages/post/[slug].tsx
+++ b/pages/post/[slug].tsx
@@ -8,7 +8,6 @@ import Image from 'next/image';
 import useSanityImage from 'hooks/useSanityImage';
 import { blurImageUrl } from 'constants/image';
 import { Routes } from 'constants/routes';
-import { useRouter } from 'next/router';
 
 interface PostProps {
   post: IPost;
@@ -91,10 +90,10 @@ export const getStaticPaths = async () => {
 export const getStaticProps: GetStaticProps<PostProps> = async ({ params }) => {
   const post = await client.fetch(singlePostQuery, { slug: params?.slug });
 
-  if(!post) {
+  if (!post) {
     return {
-      notFound: true
-    }
+      notFound: true,
+    };
   }
 
   return {

--- a/pages/post/[slug].tsx
+++ b/pages/post/[slug].tsx
@@ -73,7 +73,7 @@ export const getStaticPaths = async () => {
         slug: post.slug.current,
       },
     })),
-    fallback: false,
+    fallback: "blocking",
   };
 };
 

--- a/pages/post/[slug].tsx
+++ b/pages/post/[slug].tsx
@@ -8,14 +8,27 @@ import Image from 'next/image';
 import useSanityImage from 'hooks/useSanityImage';
 import { blurImageUrl } from 'constants/image';
 import { Routes } from 'constants/routes';
+import { useRouter } from 'next/router';
 
 interface PostProps {
   post: IPost;
 }
 
 const Post = ({ post }: PostProps) => {
-  const { title, _createdAt, categories, mainImage, content, description, slug, estimatedReadingTime } =
-    post;
+  const router = useRouter();
+  if (router.isFallback) {
+    console.warn("I'm the fallback!!", post);
+  }
+  const {
+    title,
+    _createdAt,
+    categories,
+    mainImage,
+    content,
+    description,
+    slug,
+    estimatedReadingTime,
+  } = post;
 
   const imageProps = useSanityImage(mainImage);
   return (
@@ -31,8 +44,10 @@ const Post = ({ post }: PostProps) => {
       <Title animated={false}>{title}</Title>
       <div className="container mt-4 flex max-w-screen-lg flex-col items-center gap-4">
         <div className="flex gap-2">
-          <time>{getFormattedPostDate(_createdAt)}</time>
-          · <span>{estimatedReadingTime === 0 ? '< 1' : estimatedReadingTime} min read</span>
+          <time>{getFormattedPostDate(_createdAt)}</time>·{' '}
+          <span>
+            {estimatedReadingTime === 0 ? '< 1' : estimatedReadingTime} min read
+          </span>
         </div>
         <div className="flex flex-wrap gap-1">
           {categories?.map((category) => (
@@ -73,7 +88,7 @@ export const getStaticPaths = async () => {
         slug: post.slug.current,
       },
     })),
-    fallback: "blocking",
+    fallback: 'blocking',
   };
 };
 

--- a/pages/post/[slug].tsx
+++ b/pages/post/[slug].tsx
@@ -95,6 +95,12 @@ export const getStaticPaths = async () => {
 export const getStaticProps: GetStaticProps<PostProps> = async ({ params }) => {
   const post = await client.fetch(singlePostQuery, { slug: params?.slug });
 
+  if(!post) {
+    return {
+      notFound: true
+    }
+  }
+
   return {
     props: {
       post,

--- a/pages/post/[slug].tsx
+++ b/pages/post/[slug].tsx
@@ -15,10 +15,6 @@ interface PostProps {
 }
 
 const Post = ({ post }: PostProps) => {
-  const router = useRouter();
-  if (router.isFallback) {
-    console.warn("I'm the fallback!!", post);
-  }
   const {
     title,
     _createdAt,


### PR DESCRIPTION
Use` notFound: true ` in getStaticProps and 'fallback:blocking' to retrieve and build HTML on page load request 