### PR TITLE
Introduce full height property for page

### DIFF
--- a/pages/[[...slug]].tsx
+++ b/pages/[[...slug]].tsx
@@ -12,7 +12,7 @@ interface PageProps {
 }
 
 const Page = ({ siteConfig, data }: PageProps) => {
-  const { title, pageTitle, content, slug, ogDescription } = data;
+  const { title, pageTitle, content, slug, ogDescription, fullHeight } = data;
 
   return (
     <Layout
@@ -21,6 +21,7 @@ const Page = ({ siteConfig, data }: PageProps) => {
       description={ogDescription}
       // openGraphImage={mainImage}
       slug={slug.current}
+      fullHeight={fullHeight}
     >
       {(pageTitle || title) && (
         <Title className="mb-8">{!!pageTitle ? pageTitle : title}</Title>

--- a/studio/schemas/documents/page.ts
+++ b/studio/schemas/documents/page.ts
@@ -61,6 +61,13 @@ export default defineType(
           'Specific site description for Open Graph. When empty default description is used',
       },
       {
+        name: 'fullHeight',
+        type: "boolean",
+        title: "Use full height for content",
+        initialValue: false,
+        description: "Use full height for content, to position it in the center. Useful for small content"
+      },
+      {
         name: 'content',
         type: 'array',
         title: 'Content',

--- a/types/page.d.ts
+++ b/types/page.d.ts
@@ -8,6 +8,7 @@ export interface Page {
   ogDescription?: string;
   enabled: boolean;
   language?: string;
+  fullHeight?: boolean;
 }
 
 export interface ContentBlock {


### PR DESCRIPTION
* Introduced `fullHeight` property for page, to show content centered, which is useless for content with small heights