### PR TITLE
Make resume field in site config multi-language ready

### DIFF
--- a/constants/groq.ts
+++ b/constants/groq.ts
@@ -71,7 +71,7 @@ export const allTranslationQuery = groq`
 export const configQuery = groq`
 *[_type == "siteconfig"][0] {
   ...,
-  "resume": resume {
+  "resume": resume[$lang] {
     ...,
     asset->
   },

--- a/studio/schemas/documents/siteConfig.ts
+++ b/studio/schemas/documents/siteConfig.ts
@@ -1,5 +1,6 @@
 import { defineType, Rule } from 'sanity';
 import { i18nConfig } from '../../config/i18n';
+import { getLocalizedObject } from '../../utils/schema';
 export default defineType({
   name: 'siteconfig',
   type: 'document',
@@ -169,15 +170,12 @@ export default defineType({
       fieldset: 'menu',
     },
     {
+      ...getLocalizedObject('file', { accept: '.pdf' }),
       name: 'resume',
       title: 'Resume',
       description:
         'Resume, which can be downloaded from the menu. Empty when should not been shown.',
-      type: 'file',
       fieldset: 'menu',
-      options: {
-        accept: '.pdf',
-      },
     },
 
     {

--- a/studio/utils/schema.ts
+++ b/studio/utils/schema.ts
@@ -4,7 +4,7 @@ import { documentTypeIcons } from '../constants/sanity';
 import { SchemaType } from 'sanity';
 import { getLanguagesWithoutBase } from './i18n';
 
-export const getLocalizedObject = (fieldType: string) => {
+export const getLocalizedObject = (fieldType: string, fieldOptions?: any) => {
   return {
     title: `Localized ${fieldType}`,
     name: `locale${fieldType.charAt(0).toUpperCase()}${fieldType.substring(1)}`,
@@ -22,6 +22,7 @@ export const getLocalizedObject = (fieldType: string) => {
       name: lang.id,
       type: fieldType,
       fieldset: lang.id === i18nConfig.base ? null : 'translations',
+      ...(fieldOptions ? { options: fieldOptions } : {}),
     })),
   };
 };


### PR DESCRIPTION
* Convert resume field in siteConfig to multi-language file
* Get only resume for current language in frontend 